### PR TITLE
README.asciidoc: Fix links (asciidoc is not markdown :-/)

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -78,12 +78,12 @@ You need a C++11 compiler installed to build.
 
 That should build the `daemon-manager` and `dmctl` binaries.
 
-If you want to build the man pages you'll need [AsciiDoc](https://asciidoc.org)
+If you want to build the man pages you'll need https://asciidoc.org[AsciiDoc]
 installed. On a Debian or Ubuntu system shhould be as easy as:
 
   sudo apt install asciidoc
 
-On macOS, get [Homebrew](https://brew.sh) and then:
+On macOS, get https://brew.sh[Homebrew] and then:
 
   brew install asciidoc
 


### PR DESCRIPTION
README.asciidoc: Fix links (asciidoc is not markdown :-/)